### PR TITLE
Add trauma feedback app example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # hello-world
+
 tutorial repository
 student of medicine with a fascination in computer programming
 commit to show how to commit
+
+## Projects
+
+- [Trauma Feedback App](./trauma-feedback-app): sample React Native application allowing trauma providers to scan a QR code and submit feedback.

--- a/trauma-feedback-app/App.js
+++ b/trauma-feedback-app/App.js
@@ -1,0 +1,80 @@
+import React, { useState, useEffect } from 'react';
+import { StyleSheet, Text, View, Button, TextInput } from 'react-native';
+import { BarCodeScanner } from 'expo-barcode-scanner';
+
+export default function App() {
+  const [hasPermission, setHasPermission] = useState(null);
+  const [scanned, setScanned] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await BarCodeScanner.requestPermissionsAsync();
+      setHasPermission(status === 'granted');
+    })();
+  }, []);
+
+  if (hasPermission === null) {
+    return <Text>Requesting camera permission...</Text>;
+  }
+  if (hasPermission === false) {
+    return <Text>No access to camera</Text>;
+  }
+
+  const handleBarCodeScanned = () => {
+    setScanned(true);
+  };
+
+  const handleSubmit = () => {
+    setSubmitted(true);
+  };
+
+  return (
+    <View style={styles.container}>
+      {!scanned ? (
+        <BarCodeScanner
+          onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+          style={StyleSheet.absoluteFillObject}
+        />
+      ) : !submitted ? (
+        <View style={styles.form}>
+          <Text style={styles.label}>Provide feedback about the activation:</Text>
+          <TextInput
+            placeholder="What worked or didn't work?"
+            value={feedback}
+            onChangeText={setFeedback}
+            multiline
+            style={styles.input}
+          />
+          <Button title="Submit" onPress={handleSubmit} />
+        </View>
+      ) : (
+        <Text>Thank you for your feedback!</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  form: {
+    padding: 20,
+  },
+  label: {
+    marginBottom: 10,
+    fontSize: 18,
+  },
+  input: {
+    height: 100,
+    width: 250,
+    borderColor: 'gray',
+    borderWidth: 1,
+    padding: 10,
+    marginBottom: 10,
+  },
+});

--- a/trauma-feedback-app/README.md
+++ b/trauma-feedback-app/README.md
@@ -1,0 +1,28 @@
+# Trauma Feedback App
+
+This is a simple mobile app built with Expo/React Native. Trauma providers can scan the QR code in front of the trauma bay to check in and then submit feedback on the activation.
+
+## Prerequisites
+
+- Install [Node.js](https://nodejs.org/)
+- Install Expo CLI:
+
+```bash
+npm install -g expo-cli
+```
+
+- Install the project dependencies:
+
+```bash
+npm install
+```
+
+## Running the App
+
+Start the development server:
+
+```bash
+expo start
+```
+
+Use the Expo Go app or an emulator to run the application on your device. Scanning the QR code will display a feedback form where providers can describe what worked or didn't work.

--- a/trauma-feedback-app/package.json
+++ b/trauma-feedback-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "trauma-feedback-app",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "expo": "~50.0.0",
+    "expo-barcode-scanner": "~12.5.1",
+    "react": "18.2.0",
+    "react-native": "0.73.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add a sample React Native app that scans a QR code and prompts for feedback
- document how to run the app
- update root README with link to the new project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68488c96d6b083248ad7156bf250095c