### PR TITLE
Add Expo Hello World mobile app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ commit to show how to commit
 
 ## Projects
 
+- [Hello World App](./hello-world-app): minimal Expo app displaying a friendly greeting.
 - [Trauma Feedback App](./trauma-feedback-app): sample React Native application allowing trauma providers to scan a QR code and submit feedback.

--- a/hello-world-app/App.js
+++ b/hello-world-app/App.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Hello, World!</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/hello-world-app/README.md
+++ b/hello-world-app/README.md
@@ -1,0 +1,15 @@
+# Hello World App
+
+Simple React Native application built with Expo that displays a greeting.
+
+## Running
+
+1. Install dependencies:
+   ```
+   npm install
+   ```
+2. Start the development server:
+   ```
+   npm start
+   ```
+3. Scan the QR code with the Expo Go app on your phone to launch the app.

--- a/hello-world-app/app.json
+++ b/hello-world-app/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "HelloWorld",
+    "slug": "hello-world-app",
+    "version": "1.0.0",
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/hello-world-app/package.json
+++ b/hello-world-app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hello-world-app",
+  "version": "1.0.0",
+  "private": true,
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~50.0.0",
+    "expo-status-bar": "~1.11.1",
+    "react": "18.2.0",
+    "react-native": "0.73.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add simple Expo Hello World app that renders a greeting
- document how to run the app on a phone

## Testing
- `npm test --prefix hello-world-app` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68993e3bb4c483249f99de596913908b